### PR TITLE
fix: Replace newline characters with spaces in comment content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@ config.py
 .idea
 .vscode
 __pycache__
-ids_collection/collection_01/
-ids_collection/collection_02/
+ids_collection/*
 resume_checkpoint.txt
-output/*.csv
-output/collection_01/*.csv
-output/collection_02/*.csv
+output/*
+
+# Mac OS
+.DS_Store

--- a/com_spider.py
+++ b/com_spider.py
@@ -101,7 +101,7 @@ class JDCommentSpider:
         for comment in comments:
             user_id = comment.get('id', '')
             user_name = comment.get('nickname', '')
-            content = comment.get('content', '')
+            content = comment.get('content', '').replace('\n', ' ')  # replace newline characters with spaces
             create_time = comment.get('creationTime', '')
             score = comment.get('score', '')
             location = comment.get('location', '')


### PR DESCRIPTION
Hi Duguce,
Thank you for providing the crawler, it is very effective for me. However, I discovered a bug during its use: if a comment spans multiple lines, the newline characters are preserved when saved directly, which affects subsequent CSV reading just like the image below. Therefore, I replaced the newline characters with spaces when saving.

![image](https://github.com/Duguce/JdSpider/assets/56749226/f0603f83-e703-4134-b561-bdba8ab65eea)

Hobee.